### PR TITLE
Fixing HuggingFace LayerNorm.weight reference - replacing with PyTorch equivalents

### DIFF
--- a/mingpt/trainer.py
+++ b/mingpt/trainer.py
@@ -60,7 +60,7 @@ class Trainer:
         model, config = self.model, self.config
 
         # create the optimizer
-        no_decay = ["bias", "LayerNorm.weight"]
+        no_decay = ["bias", "ln1.weight", "ln2.weight"]
         params_decay = [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)]
         params_nodecay = [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)]
         optim_groups = [

--- a/mingpt/trainer.py
+++ b/mingpt/trainer.py
@@ -60,7 +60,7 @@ class Trainer:
         model, config = self.model, self.config
 
         # create the optimizer
-        no_decay = ["bias", "ln1.weight", "ln2.weight"]
+        no_decay = ["bias", "ln1.weight", "ln2.weight", "ln_f.weight"]
         params_decay = [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)]
         params_nodecay = [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)]
         optim_groups = [


### PR DESCRIPTION
A reference to "LayerNorm.weight" looks like it may have been ported from a HuggingFace implementation - when running locally the values that I need to exclude from weight decay in this implementation are "ln1.weight", "ln2.weight" and "ln_f.weight".

Update:  I've created another PR with a more generic fix for this issue:   https://github.com/karpathy/minGPT/pull/18

Thanks for putting out this awesome code - I'm working on a Java implementation of gpt and couldn't find any existing code to reference that contained both the sampling and training steps without introducing a lot of complexity or superfluous frameworks.   This is a really helpful project  - many thanks!