### PR TITLE
More generic fix for HuggingFace LayerNorm.weight reference - replacing with PyTorch equivalents

### DIFF
--- a/mingpt/trainer.py
+++ b/mingpt/trainer.py
@@ -60,7 +60,7 @@ class Trainer:
         model, config = self.model, self.config
 
         # create the optimizer
-        no_decay = ["bias", "LayerNorm.weight"]
+        no_decay = ["bias", "ln1.weight", "ln2.weight"]
         params_decay = [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)]
         params_nodecay = [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)]
         optim_groups = [

--- a/mingpt/trainer.py
+++ b/mingpt/trainer.py
@@ -60,7 +60,7 @@ class Trainer:
         model, config = self.model, self.config
 
         # create the optimizer
-        no_decay = ["bias", "ln1.weight", "ln2.weight"]
+        no_decay = ["bias", "ln1.weight", "ln2.weight", "ln_f.weight"]
         params_decay = [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)]
         params_nodecay = [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)]
         optim_groups = [


### PR DESCRIPTION
I read on the README that "mingpt/trainer.py is (GPT-independent) PyTorch boilerplate" and realised the previous fix (https://github.com/karpathy/minGPT/pull/16 ) for the layer norm weight exclusion was coupled to the GPT structure.

This PR should resolve that by allowing a set of module types to be configured whose parameters are to be excluded from weight decay.