### PR TITLE
Weight decay exclusions

### DIFF
--- a/mingpt/trainer.py
+++ b/mingpt/trainer.py
@@ -60,7 +60,7 @@ class Trainer:
         model, config = self.model, self.config
 
         # create the optimizer
-        no_decay = ["bias", "LayerNorm.weight"]
+        no_decay = ["bias", "ln1.weight", "ln2.weight"]
         params_decay = [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)]
         params_nodecay = [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)]
         optim_groups = [

--- a/mingpt/trainer.py
+++ b/mingpt/trainer.py
@@ -60,7 +60,7 @@ class Trainer:
         model, config = self.model, self.config
 
         # create the optimizer
-        no_decay = ["bias", "ln1.weight", "ln2.weight"]
+        no_decay = ["bias", "ln1.weight", "ln2.weight", "ln_f.weight"]
         params_decay = [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)]
         params_nodecay = [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)]
         optim_groups = [


### PR DESCRIPTION
Excluding Parameters from weight decay by default which are:

*  Freestanding ( not nested with a Module)
*  Within LayerNorm or Embedding modules

A list of parameter name overrides can be configured with TrainerConfig that allow specific Parameters to be included with weight decay
