### PR TITLE
fix CharDataset::__len__ off by one error

### DIFF
--- a/play_char.ipynb
+++ b/play_char.ipynb
@@ -70,7 +70,7 @@
     "        self.data = data\n",
     "    \n",
     "    def __len__(self):\n",
-    "        return len(self.data) - (self.block_size + 1)\n",
+    "        return len(self.data) - self.block_size\n",
     "\n",
     "    def __getitem__(self, idx):\n",
     "        # grab a chunk of (block_size + 1) characters from the data\n",


### PR DESCRIPTION
I made an off by one mistake in my comments on issue #22, which unfortunately got rolled into 339f4e7.  Sorry about that!

Verified by example:

```
>>> data = list(range(8))
>>> len(data)
8
>>> block_size = 4
>>> 
>>> 
>>> for i in range(len(data) - block_size):
...     print(i)
...     print(data[i:i+block_size+1])
... 
0
[0, 1, 2, 3, 4]
1
[1, 2, 3, 4, 5]
2
[2, 3, 4, 5, 6]
3
[3, 4, 5, 6, 7]
>>> for i in range(len(data) - (block_size+1)):
...     print(i)
...     print(data[i:i+block_size+1])
... 
0
[0, 1, 2, 3, 4]
1
[1, 2, 3, 4, 5]
2
[2, 3, 4, 5, 6]
```