### PR TITLE
move instantiation of DataLoader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .ipynb_checkpoints/
 __pycache__/
+*.swp


### PR DESCRIPTION
It's unnecessary to instantiate the Dataloader at every epoch. The shuffle parameter set to true suffices.