### PR TITLE
perform sqrt-d scaling on q instead of att matrix

### DIFF
--- a/mingpt/model.py
+++ b/mingpt/model.py
@@ -67,7 +67,9 @@ class CausalSelfAttention(nn.Module):
         v = self.value(x).view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
 
         # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
-        att = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(k.size(-1)))
+        # perform sqrt(d) scaling on (B, nh, T, hs) instead of (B, nh, T, T).
+        q = q * (1.0 / math.sqrt(k.size(-1)))
+        att = (q @ k.transpose(-2, -1))
         att = att.masked_fill(self.mask[:,:,:T,:T] == 0, float('-inf'))
         att = F.softmax(att, dim=-1)
         att = self.attn_drop(att)


### PR DESCRIPTION
Andrej,

Firstly, thanks for creating such a concise version! Learned a lot!

For sqrt(d) scaling, it is better to do it directly on the query (or key) instead of the att matrix which typically hogs more memory due to `[batch_size, heads, seq_len, seq_len]` shape compared to `[batch_size, heads, seq_len, head_dim]`. In this demo, `seq_len=128` and `head_dim`=64.