### PR TITLE
initialize position embeddings

### DIFF
--- a/mingpt/model.py
+++ b/mingpt/model.py
@@ -124,12 +124,14 @@ class GPT(nn.Module):
 
     def _init_weights(self, module):
         if isinstance(module, (nn.Linear, nn.Embedding)):
-            module.weight.data.normal_(mean=0.0, std=0.02)
+            torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
             if isinstance(module, nn.Linear) and module.bias is not None:
-                module.bias.data.zero_()
+                torch.nn.init.zeros_(module.bias)
         elif isinstance(module, nn.LayerNorm):
-            module.bias.data.zero_()
-            module.weight.data.fill_(1.0)
+            torch.nn.init.zeros_(module.bias)
+            torch.nn.init.ones_(module.weight)
+        elif isinstance(module, GPT):
+            torch.nn.init.normal_(module.pos_emb, mean=0.0, std=0.02)
 
     def configure_optimizers(self, train_config):
         """


### PR DESCRIPTION
Hi Andrej,
thank you for making minGPT, it is an awesome repo! (I'm working on making it only the second best educational resource for transformers, but it is hard work to even try.)

But here is a small thing:
The position embeddings are initialized to 0 in your code.
The attached PR changes this to random normal std=0.02 .
This seems to be what everyone does and indeed the play char example (with batch size 384 due to memory limitations and otherwise unchanged) seems to benefit a bit:

0-init:
```
epoch 1: train loss 0.31366
epoch 2: train loss 0.16633
```

fixed init:
```
epoch 1 train loss 0.25942
epoch 2 train loss 0.15616
```

I imagine larger block sizes might benefit relatively more.

I also took the liberty to change from using the long-deprecated `.data` to `torch.nn.init.*`, but of course, you may or may not appreciate that.
