### PR TITLE
#71 use config n_head instead of hardcoded 4 heads

### DIFF
--- a/mingpt/model.py
+++ b/mingpt/model.py
@@ -87,9 +87,9 @@ class Block(nn.Module):
         self.ln2 = nn.LayerNorm(config.n_embd)
         self.attn = CausalSelfAttention(config)
         self.mlp = nn.Sequential(
-            nn.Linear(config.n_embd, 4 * config.n_embd),
+            nn.Linear(config.n_embd, config.n_head * config.n_embd),
             nn.GELU(),
-            nn.Linear(4 * config.n_embd, config.n_embd),
+            nn.Linear(config.n_head * config.n_embd, config.n_embd),
             nn.Dropout(config.resid_pdrop),
         )
 


### PR DESCRIPTION
use config n_head instead of hardcoded 4 heads in model attention block