### PR TITLE
Add setup.py to allow mingpt to be used as a third-party library

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ The minGPT library is three files: [mingpt/model.py](mingpt/model.py) contains t
 - `demo.ipynb` shows a minimal usage of the `GPT` and `Trainer` in a notebook format on a simple sorting example
 - `generate.ipynb` shows how one can load a pretrained GPT2 and generate text given some prompt
 
+### Library Installation
+
+If you want to `import mingpt` into your project:
+
+```
+git clone https://github.com/karpathy/minGPT.git
+cd minGPT
+pip install -e .
+```
+
 ### Usage
 
 Here's how you'd instantiate a GPT-2 (124M param version):

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(name='minGPT',
+      version='0.0.1',
+      author='Andrej Karpathy',
+      packages=['mingpt'],
+      description='A PyTorch re-implementation of GPT',
+      license='MIT',
+      install_requires=[
+            'torch',
+      ],
+)


### PR DESCRIPTION
add a setup.py file so I can import mingpt into my projects. Let me know if there is a specific version number I should mark this as.

Usage:
```
cd minGPT
pip install -e .
```