### PR TITLE
Add DataParallel and make Block support DataParallel

### DIFF
--- a/mingpt/model.py
+++ b/mingpt/model.py
@@ -84,12 +84,14 @@ class Block(nn.Module):
             act     = NewGELU(),
             dropout = nn.Dropout(config.resid_pdrop),
         ))
-        m = self.mlp
-        self.mlpf = lambda x: m.dropout(m.c_proj(m.act(m.c_fc(x)))) # MLP forward
+        # m = self.mlp
+        # self.mlpf = lambda x: m.dropout(m.c_proj(m.act(m.c_fc(x)))) # MLP forward
 
     def forward(self, x):
         x = x + self.attn(self.ln_1(x))
-        x = x + self.mlpf(self.ln_2(x))
+        m = self.mlp
+        # x = x + self.mlpf(self.ln_2(x))
+        x = x + m.dropout(m.c_proj(m.act(m.c_fc(self.ln_2(x))))) # MLP forward
         return x
 
 class GPT(nn.Module):

--- a/mingpt/model.py
+++ b/mingpt/model.py
@@ -84,13 +84,10 @@ class Block(nn.Module):
             act     = NewGELU(),
             dropout = nn.Dropout(config.resid_pdrop),
         ))
-        # m = self.mlp
-        # self.mlpf = lambda x: m.dropout(m.c_proj(m.act(m.c_fc(x)))) # MLP forward
 
     def forward(self, x):
         x = x + self.attn(self.ln_1(x))
         m = self.mlp
-        # x = x + self.mlpf(self.ln_2(x))
         x = x + m.dropout(m.c_proj(m.act(m.c_fc(self.ln_2(x))))) # MLP forward
         return x
 

--- a/mingpt/trainer.py
+++ b/mingpt/trainer.py
@@ -27,6 +27,7 @@ class Trainer:
         C.betas = (0.9, 0.95)
         C.weight_decay = 0.1 # only applied on matmul weights
         C.grad_norm_clip = 1.0
+        C.data_parallel = True
         return C
 
     def __init__(self, config, model, train_dataset):
@@ -65,7 +66,7 @@ class Trainer:
         # setup the optimizer
         self.optimizer = model.configure_optimizers(config)
 
-        if torch.cuda.device_count() > 1:
+        if torch.cuda.device_count() > 1 and config.data_parallel:
             model = nn.DataParallel(model)
             model.to(self.device)
 


### PR DESCRIPTION
There's a lambda function in Block that causes errors when trying to train with DataParallel enabled. I'm not sure if you want to add DataParallel to minGPT because maybe that's not minimal enough. Could reduce this to just make the change to `mingpt/model.py` to eliminate the error if people use DataParallel with this model.

Example error:

```
Traceback (most recent call last):                                                                                                                                                                                                  [404/9341]
  File "projects/chargpt/chargpt.py", line 134, in <module>
    trainer.run()
  File "/h/gngdb/repos/minGNS/mingpt/trainer.py", line 97, in run
    logits, self.loss = model(x, y)
  File "/nobackup/gngdb/envs/humor_env/lib/python3.7/site-packages/torch/nn/modules/module.py", line 1130, in _call_impl
    return forward_call(*input, **kwargs)
  File "/nobackup/gngdb/envs/humor_env/lib/python3.7/site-packages/torch/nn/parallel/data_parallel.py", line 168, in forward
    outputs = self.parallel_apply(replicas, inputs, kwargs)
  File "/nobackup/gngdb/envs/humor_env/lib/python3.7/site-packages/torch/nn/parallel/data_parallel.py", line 178, in parallel_apply
    return parallel_apply(replicas, inputs, kwargs, self.device_ids[:len(replicas)])
  File "/nobackup/gngdb/envs/humor_env/lib/python3.7/site-packages/torch/nn/parallel/parallel_apply.py", line 86, in parallel_apply
    output.reraise()
  File "/nobackup/gngdb/envs/humor_env/lib/python3.7/site-packages/torch/_utils.py", line 461, in reraise
    raise exception
RuntimeError: Caught RuntimeError in replica 1 on device 1.
Original Traceback (most recent call last):
  File "/nobackup/gngdb/envs/humor_env/lib/python3.7/site-packages/torch/nn/parallel/parallel_apply.py", line 61, in _worker
    output = module(*input, **kwargs)
  File "/nobackup/gngdb/envs/humor_env/lib/python3.7/site-packages/torch/nn/modules/module.py", line 1130, in _call_impl
    return forward_call(*input, **kwargs)
  File "/h/gngdb/repos/minGNS/mingpt/model.py", line 271, in forward
    x = block(x)                       
  File "/nobackup/gngdb/envs/humor_env/lib/python3.7/site-packages/torch/nn/modules/module.py", line 1130, in _call_impl
    return forward_call(*input, **kwargs)
  File "/h/gngdb/repos/minGNS/mingpt/model.py", line 92, in forward                                           
    x = x + self.mlpf(self.ln_2(x))                                             
  File "/h/gngdb/repos/minGNS/mingpt/model.py", line 88, in <lambda>           
    self.mlpf = lambda x: m.dropout(m.c_proj(m.act(m.c_fc(x)))) # MLP forward      
  File "/nobackup/gngdb/envs/humor_env/lib/python3.7/site-packages/torch/nn/modules/module.py", line 1130, in _call_impl
    return forward_call(*input, **kwargs)                                       
  File "/nobackup/gngdb/envs/humor_env/lib/python3.7/site-packages/torch/nn/modules/linear.py", line 114, in forward
    return F.linear(input, self.weight, self.bias)         
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cuda:1! (when checking argument for argument mat1 in method wrapper_addmm)
```

Removing the lambda function resolves it, although I don't fully understand why.