### PR TITLE
More consistent variable naming

### DIFF
--- a/mingpt/model.py
+++ b/mingpt/model.py
@@ -35,11 +35,11 @@ class CausalSelfAttention(nn.Module):
 
     def __init__(self, config):
         super().__init__()
-        assert config.n_embd % config.n_head == 0
+        assert config.embd_dim % config.n_head == 0
         # key, query, value projections for all heads, but in a batch
-        self.c_attn = nn.Linear(config.n_embd, 3 * config.n_embd)
+        self.c_attn = nn.Linear(config.embd_dim, 3 * config.embd_dim) # `c_attn` means `concatenated attention`
         # output projection
-        self.c_proj = nn.Linear(config.n_embd, config.n_embd)
+        self.c_proj = nn.Linear(config.embd_dim, config.embd_dim) # `c_proj` means `concatenated projection`
         # regularization
         self.attn_dropout = nn.Dropout(config.attn_pdrop)
         self.resid_dropout = nn.Dropout(config.resid_pdrop)
@@ -47,23 +47,23 @@ class CausalSelfAttention(nn.Module):
         self.register_buffer("bias", torch.tril(torch.ones(config.block_size, config.block_size))
                                      .view(1, 1, config.block_size, config.block_size))
         self.n_head = config.n_head
-        self.n_embd = config.n_embd
+        self.embd_dim = config.embd_dim
 
     def forward(self, x):
-        B, T, C = x.size() # batch size, sequence length, embedding dimensionality (n_embd)
+        B, T, C = x.size() # batch size, sequence length, embedding dimensionality (embd_dim)
 
         # calculate query, key, values for all heads in batch and move head forward to be the batch dim
-        q, k ,v  = self.c_attn(x).split(self.n_embd, dim=2)
+        q, k ,v  = self.c_attn(x).split(self.embd_dim, dim=2)
         k = k.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
         q = q.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
         v = v.view(B, T, self.n_head, C // self.n_head).transpose(1, 2) # (B, nh, T, hs)
 
         # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
-        att = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(k.size(-1)))
-        att = att.masked_fill(self.bias[:,:,:T,:T] == 0, float('-inf'))
-        att = F.softmax(att, dim=-1)
-        att = self.attn_dropout(att)
-        y = att @ v # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
+        attn = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(k.size(-1)))
+        attn = attn.masked_fill(self.bias[:,:,:T,:T] == 0, float('-inf'))
+        attn = F.softmax(attn, dim=-1)
+        attn = self.attn_dropout(attn)
+        y = attn @ v # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
         y = y.transpose(1, 2).contiguous().view(B, T, C) # re-assemble all head outputs side by side
 
         # output projection
@@ -75,12 +75,12 @@ class Block(nn.Module):
 
     def __init__(self, config):
         super().__init__()
-        self.ln_1 = nn.LayerNorm(config.n_embd)
+        self.ln_1 = nn.LayerNorm(config.embd_dim)
         self.attn = CausalSelfAttention(config)
-        self.ln_2 = nn.LayerNorm(config.n_embd)
+        self.ln_2 = nn.LayerNorm(config.embd_dim)
         self.mlp = nn.ModuleDict(dict(
-            c_fc    = nn.Linear(config.n_embd, 4 * config.n_embd),
-            c_proj  = nn.Linear(4 * config.n_embd, config.n_embd),
+            c_fc    = nn.Linear(config.embd_dim, 4 * config.embd_dim),
+            c_proj  = nn.Linear(4 * config.embd_dim, config.embd_dim),
             act     = NewGELU(),
             dropout = nn.Dropout(config.resid_pdrop),
         ))
@@ -98,11 +98,11 @@ class GPT(nn.Module):
     @staticmethod
     def get_default_config():
         C = CN()
-        # either model_type or (n_layer, n_head, n_embd) must be given in the config
+        # either model_type or (n_layer, n_head, embd_dim) must be given in the config
         C.model_type = 'gpt'
         C.n_layer = None
         C.n_head = None
-        C.n_embd =  None
+        C.embd_dim =  None
         # these options must be filled in externally
         C.vocab_size = None
         C.block_size = None
@@ -119,36 +119,36 @@ class GPT(nn.Module):
         self.block_size = config.block_size
 
         type_given = config.model_type is not None
-        params_given = all([config.n_layer is not None, config.n_head is not None, config.n_embd is not None])
+        params_given = all([config.n_layer is not None, config.n_head is not None, config.embd_dim is not None])
         assert type_given ^ params_given # exactly one of these (XOR)
         if type_given:
             # translate from model_type to detailed configuration
             config.merge_from_dict({
                 # names follow the huggingface naming conventions
                 # GPT-1
-                'openai-gpt':   dict(n_layer=12, n_head=12, n_embd=768),  # 117M params
+                'openai-gpt':   dict(n_layer=12, n_head=12, embd_dim=768),  # 117M params
                 # GPT-2 configs
-                'gpt2':         dict(n_layer=12, n_head=12, n_embd=768),  # 124M params
-                'gpt2-medium':  dict(n_layer=24, n_head=16, n_embd=1024), # 350M params
-                'gpt2-large':   dict(n_layer=36, n_head=20, n_embd=1280), # 774M params
-                'gpt2-xl':      dict(n_layer=48, n_head=25, n_embd=1600), # 1558M params
+                'gpt2':         dict(n_layer=12, n_head=12, embd_dim=768),  # 124M params
+                'gpt2-medium':  dict(n_layer=24, n_head=16, embd_dim=1024), # 350M params
+                'gpt2-large':   dict(n_layer=36, n_head=20, embd_dim=1280), # 774M params
+                'gpt2-xl':      dict(n_layer=48, n_head=25, embd_dim=1600), # 1558M params
                 # Gophers
-                'gopher-44m':   dict(n_layer=8, n_head=16, n_embd=512),
+                'gopher-44m':   dict(n_layer=8, n_head=16, embd_dim=512),
                 # (there are a number more...)
                 # I made these tiny models up
-                'gpt-mini':     dict(n_layer=6, n_head=6, n_embd=192),
-                'gpt-micro':    dict(n_layer=4, n_head=4, n_embd=128),
-                'gpt-nano':     dict(n_layer=3, n_head=3, n_embd=48),
+                'gpt-mini':     dict(n_layer=6, n_head=6, embd_dim=192),
+                'gpt-micro':    dict(n_layer=4, n_head=4, embd_dim=128),
+                'gpt-nano':     dict(n_layer=3, n_head=3, embd_dim=48),
             }[config.model_type])
 
         self.transformer = nn.ModuleDict(dict(
-            wte = nn.Embedding(config.vocab_size, config.n_embd),
-            wpe = nn.Embedding(config.block_size, config.n_embd),
+            wte = nn.Embedding(config.vocab_size, config.embd_dim), # word to embedding
+            wpe = nn.Embedding(config.block_size, config.embd_dim), # word to position embedding
             drop = nn.Dropout(config.embd_pdrop),
             h = nn.ModuleList([Block(config) for _ in range(config.n_layer)]),
-            ln_f = nn.LayerNorm(config.n_embd),
+            ln_f = nn.LayerNorm(config.embd_dim),
         ))
-        self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
+        self.lm_head = nn.Linear(config.embd_dim, config.vocab_size, bias=False)
 
         # init all weights, and apply a special scaled init to the residual projections, per GPT-2 paper
         self.apply(self._init_weights)
@@ -259,14 +259,14 @@ class GPT(nn.Module):
 
     def forward(self, idx, targets=None):
         device = idx.device
-        b, t = idx.size()
-        assert t <= self.block_size, f"Cannot forward sequence of length {t}, block size is only {self.block_size}"
-        pos = torch.arange(0, t, dtype=torch.long, device=device).unsqueeze(0) # shape (1, t)
+        B, T = idx.size()
+        assert T <= self.block_size, f"Cannot forward sequence of length {T}, block size is only {self.block_size}"
+        pos = torch.arange(0, T, dtype=torch.long, device=device).unsqueeze(0) # shape (1, T)
 
         # forward the GPT model itself
-        tok_emb = self.transformer.wte(idx) # token embeddings of shape (b, t, n_embd)
-        pos_emb = self.transformer.wpe(pos) # position embeddings of shape (1, t, n_embd)
-        x = self.transformer.drop(tok_emb + pos_emb)
+        tok_embd = self.transformer.wte(idx) # token embeddings of shape (B, T, embd_dim)
+        pos_embd = self.transformer.wpe(pos) # position embeddings of shape (1, T, embd_dim)
+        x = self.transformer.drop(tok_embd + pos_embd)
         for block in self.transformer.h:
             x = block(x)
         x = self.transformer.ln_f(x)


### PR DESCRIPTION
Hi @karpathy this is such an awesome repo. I was implementing it from scratch using JAX and learned quite a bit :) 

This PR proposes a more consistent naming convention.

* `n_embd` -> `embd_dim`, since we are really splitting the `embd_dim` into separate heads, which have their own `head_dim`
* `C // self.n_head` -> `head_dim` to give a better name 
* `hs` -> `hd`, to unify naming from "head size" to "head dim", which connects nicely with `embd_dm`
* `att` -> `attn` for consistency
* `tok_emb` -> `tok_embd` for consistency with using `embd` as an abbreviation for `embedding`
* `pos_emb` -> `pos_embd` for consistency with using `embd` as an abbreviation for `embedding`