### PR TITLE
Zero-grad more aggressively to save memory

### DIFF
--- a/mingpt/trainer.py
+++ b/mingpt/trainer.py
@@ -93,10 +93,10 @@ class Trainer:
             logits, self.loss = model(x, y)
 
             # backprop and update the parameters
-            model.zero_grad(set_to_none=True)
             self.loss.backward()
             torch.nn.utils.clip_grad_norm_(model.parameters(), config.grad_norm_clip)
             self.optimizer.step()
+            model.zero_grad(set_to_none=True)
 
             self.trigger_callbacks('on_batch_end')
             self.iter_num += 1


### PR DESCRIPTION
Takes a full copy of grad off the peak memory usage.

Numbers based on `torch.cuda.max_memory_allocated()`:

- For `gpt-nano`: `32019456` to `31666688`
- For `gpt2-xl`: `30634800640` to `24607903232` (6 gigabytes!)
