### PR TITLE
Check off a todo in utils: add 'freeze()' to freeze config.

### DIFF
--- a/mingpt/utils.py
+++ b/mingpt/utils.py
@@ -4,6 +4,7 @@ import sys
 import json
 import random
 from ast import literal_eval
+from collections import namedtuple
 
 import numpy as np
 import torch
@@ -31,7 +32,6 @@ def setup_logging(config):
 class CfgNode:
     """ a lightweight configuration class inspired by yacs """
     # TODO: convert to subclass from a dict like in yacs?
-    # TODO: implement freezing to prevent shooting of own foot
     # TODO: additional existence/override checks when reading/writing params?
 
     def __init__(self, **kwargs):
@@ -51,6 +51,11 @@ class CfgNode:
                 parts.append("%s: %s\n" % (k, v))
         parts = [' ' * (indent * 4) + p for p in parts]
         return "".join(parts)
+
+    def freeze(self):
+        asdict = self.to_dict()
+        frozen_cfg_builder = namedtuple('CfgNode', [k for k in asdict.keys()])
+        return frozen_cfg_builder(**asdict)
 
     def to_dict(self):
         """ return a dict representation of the config """


### PR DESCRIPTION
Adds a three-line method which uses namedtuple to create frozen configs if one wants to avoid footguns.  Checks off the 'todo' item in config.  Elements of the config are still accessible by name and as dicts.

Example usage:

```
>>> cfg = CfgNode(a=0, b=0)
>>> cfg.merge_from_args(['--a=2', '--b=3'])
command line overwriting config attribute a with 2
command line overwriting config attribute b with 3
>>> cfg_frozen = cfg.freeze()
>>> cfg_frozen.a
2
>>> a_frozen.a = 3
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[18], line 1
----> 1 cfg_frozen.cfg = 3                                                                                                                                                                                                                        
                                                                                                                       
AttributeError: can't set attribute
```