### PR TITLE
fix: correct typo in AdditionDataset explanation

### DIFF
--- a/projects/adder/adder.py
+++ b/projects/adder/adder.py
@@ -56,7 +56,7 @@ class AdditionDataset(Dataset):
 
     As one more example, the problem 6 + 39 = 45 would be encoded as:
 
-    "0639054"
+    "0639540"
 
     where you will notice that we are padding with zeros to make sure that we always
     produce strings of the exact same size: n + n + (n + 1). When n=2, this is 7.


### PR DESCRIPTION
Eliminate the confusion in the explanation of the example in the AdditionDataset comment in the adder.py file.
p.s. I’ve been stuck here for a long time.